### PR TITLE
Updated user profile to support new API format

### DIFF
--- a/lib/passport-appdotnet/strategy.js
+++ b/lib/passport-appdotnet/strategy.js
@@ -45,7 +45,7 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://alpha.app.net/oauth/authenticate';
   options.tokenURL = options.tokenURL || 'https://alpha.app.net/oauth/access_token';
   options.scopeSeparator = options.scopeSeparator || '%20';
-  
+
   OAuth2Strategy.call(this, options, verify);
   this.name = 'appdotnet';
 }
@@ -96,20 +96,20 @@ Strategy.prototype.authorizationParams = function (options) {
 Strategy.prototype.userProfile = function(accessToken, done) {
   this._oauth2.getProtectedResource('https://alpha-api.app.net/stream/0/users/me', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
-      var json = JSON.parse(body);
-      
+      var json = JSON.parse(body).data || JSON.parse(body);
+
       var profile = { provider: 'appdotnet' };
       profile.id = json.id;
       profile.username = json.username;
       profile.displayName = json.name;
       profile.gender = json.gender;
       profile.profileUrl = 'https://alpha.app.net/' + json.username;
-      
+
       profile._raw = body;
       profile._json = json;
-      
+
       done(null, profile);
     } catch(e) {
       done(e);


### PR DESCRIPTION
So it turns out when you switch to the new API, the user object returns but with 'data'. This should work for either API call.
